### PR TITLE
Add optional skip for inaccessible items and log run stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Optional `skipInaccessibleItems` configuration (and `SKIP_INACCESSIBLE_ITEMS` env override) to skip per-user updates that return HTTP 403, log skip counts, and continue processing without failing the run.
+- Run summary logging that reports processed, succeeded, failed, and skipped updates along with per-user skip counts.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See [config.yaml](https://github.com/varthe/Defaulterr/blob/main/config.yaml) fo
   - **WARNING**: The first run may take a LONG time to complete as it will update all existing media. Subsequent runs will only update any new items added since the last run.
 - **partial_run_cron_expression**: Specify a cron expression (e.g., `0 3 * * *` for daily at 3:00 AM) to do a partial run on a schedule. You can create and check cron expressions at [https://crontab.guru/](https://crontab.guru/).
 - **clean_run_on_start**: Set to `True` to update all existing media on application start. Should only be used if you want to re-apply a new set of filters on your libraries.
+- **skipInaccessibleItems**: Set to `True` to skip per-user updates that return HTTP 403 because the user can't access the item. When enabled the run will continue, log skip counts per user, and finish with exit code `0`. Defaults to `False`. You can also enable it via the `SKIP_INACCESSIBLE_ITEMS` environment variable.
 
 #### GROUPS
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ partial_run_on_start: False
 partial_run_cron_expression: "" # E.g., '0 3 * * *' to run every day at 3:00 am. See crontab.guru
 # CLEAN RUN: Updates all existing media. Should only be used if you want to re-apply a new set of filters on your libraries.
 clean_run_on_start: False
+skipInaccessibleItems: False # Skip updates that return HTTP 403 because the user cannot access the item
 # RUN SETTINGS END
 
 # MANAGED ACCOUNTS (optional)

--- a/configBuilder.js
+++ b/configBuilder.js
@@ -19,6 +19,7 @@ const schema = {
         partial_run_on_start: { type: "boolean" },
         partial_run_cron_expression: { type: "string" },
         clean_run_on_start: { type: "boolean" },
+        skipInaccessibleItems: { type: "boolean" },
         managed_users: {
             type: "object",
             additionalProperties: { type: "string" },
@@ -238,6 +239,7 @@ const loadAndValidateYAML = () => {
 
         logger.info("Validated and loaded config file")
         jsonData.plex_server_url = normalizeUrl(jsonData.plex_server_url)
+        if (typeof jsonData.skipInaccessibleItems !== "boolean") jsonData.skipInaccessibleItems = false
         return jsonData
     } catch (error) {
         logger.error(`Error loading or validating YAML: ${error.message}`)

--- a/main.js
+++ b/main.js
@@ -7,14 +7,65 @@ const cronValidator = require("cron-validator")
 const xml2js = require("xml2js")
 const loadAndValidateYAML = require("./configBuilder")
 
+const parseBoolean = (value) => {
+    if (typeof value === "boolean") return value
+    if (typeof value === "string") {
+        const normalized = value.trim().toLowerCase()
+        if (["1", "true", "yes", "on"].includes(normalized)) return true
+        if (["0", "false", "no", "off"].includes(normalized)) return false
+    }
+    return undefined
+}
+
 const config = loadAndValidateYAML()
+const envSkipInaccessibleItems = parseBoolean(process.env.SKIP_INACCESSIBLE_ITEMS)
+if (typeof envSkipInaccessibleItems === "boolean") {
+    config.skipInaccessibleItems = envSkipInaccessibleItems
+}
 const app = express()
 app.use(express.json())
 
 const STREAM_TYPES = { video: 1, audio: 2, subtitles: 3 }
 const LIBRARIES = new Map()
 const USERS = new Map()
+const runStats = {
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+    skippedByUser: {},
+}
 const timestampsFile = process.argv[4] || "./last_run_timestamps.json"
+
+const resetRunStats = () => {
+    runStats.processed = 0
+    runStats.succeeded = 0
+    runStats.failed = 0
+    runStats.skipped = 0
+    runStats.skippedByUser = {}
+}
+
+const recordSkipForUser = (username) => {
+    runStats.skipped++
+    runStats.skippedByUser[username] = (runStats.skippedByUser[username] || 0) + 1
+}
+
+const logRunSummary = () => {
+    logger.info(
+        `Run summary: processed=${runStats.processed}, succeeded=${runStats.succeeded}, failed=${runStats.failed}, skipped=${runStats.skipped}`
+    )
+    if (Object.keys(runStats.skippedByUser).length === 0) {
+        logger.info("skippedInaccessibleItemsByUser: none")
+        return
+    }
+    Object.entries(runStats.skippedByUser).forEach(([user, count]) => {
+        logger.info(`skippedInaccessibleItemsByUser[${user}] = ${count}`)
+    })
+}
+
+if (config.skipInaccessibleItems) {
+    logger.info("skipInaccessibleItems enabled: HTTP 403 responses will be skipped per user/item.")
+}
 
 // Create an Axios instance with increased timeout and keep-alive
 const axiosInstance = axios.create({
@@ -427,6 +478,8 @@ const updateDefaultStreamsPerItem = async (streamsToUpdate, filters, users) => {
                 continue
             }
             for (const username of usernames) {
+                let skipUpdate = false
+                let finalStatus
                 const token = USERS.get(username)
                 if (!token) {
                     logger.warn(`No access token found for user ${username}. Skipping update.`)
@@ -436,54 +489,82 @@ const updateDefaultStreamsPerItem = async (streamsToUpdate, filters, users) => {
                 if (stream.audioStreamId) queryParams.append("audioStreamID", stream.audioStreamId)
                 if (stream.subtitleStreamId >= 0) queryParams.append("subtitleStreamID", stream.subtitleStreamId)
 
+                runStats.processed++
+
                 try {
-                    const response = await axiosInstance
-                        .post(
+                    let response
+                    try {
+                        response = await axiosInstance.post(
                             `/library/parts/${stream.partId}?${queryParams.toString()}`,
                             {},
                             { headers: { "X-Plex-Token": token } }
                         )
-                        .catch(async (error) => {
+                        finalStatus = response.status
+                    } catch (error) {
+                        const statusCode = error.response?.status ?? error.status
+                        if (statusCode === 403 && config.skipInaccessibleItems) {
+                            skipUpdate = true
+                            recordSkipForUser(username)
+                            const itemLabel = stream.title
+                                ? `'${stream.title}' (Part ID ${stream.partId})`
+                                : `Part ID ${stream.partId}`
+                            logger.warn(
+                                `Skipping item ${itemLabel} for user ${username} in group ${group}: inaccessible (HTTP 403).`
+                            )
+                        } else {
+                            const messageSuffix =
+                                statusCode === 403
+                                    ? ". This could be because of age ratings, ensure they can access ALL items in the library"
+                                    : ""
+                            const baseMessage = error.message || error.response?.statusText || "Unknown error"
                             logger.error(
-                                `Error while posting update for user ${username} in group ${group}${
-                                    error.status === 403
-                                        ? ". This could be because of age ratings, ensure they can access ALL items in the library"
-                                        : ""
-                                }: ${error.message}. Retrying in 30 sec...`
+                                `Error while posting update for user ${username} in group ${group}${messageSuffix}: ${baseMessage}. Retrying in 30 sec...`
                             )
                             await delay(30000)
                             let responseStatus = ""
                             let attempt = 1
                             while (responseStatus !== 200 && attempt < 10) {
-                                await axiosInstance
-                                    .post(
+                                try {
+                                    response = await axiosInstance.post(
                                         `/library/parts/${stream.partId}?${queryParams.toString()}`,
                                         {},
                                         { headers: { "X-Plex-Token": token } }
                                     )
-                                    .then((response) => (responseStatus = response.status))
-                                    .catch((error) => {
-                                        logger.error(
-                                            `Attempt ${attempt}/10 failed with error: ${error.message}. Retrying in 30 sec...`
-                                        )
-                                    })
+                                    responseStatus = response.status
+                                } catch (retryError) {
+                                    logger.error(
+                                        `Attempt ${attempt}/10 failed with error: ${retryError.message}. Retrying in 30 sec...`
+                                    )
+                                }
                                 if (responseStatus !== 200) {
                                     attempt++
                                     await delay(30000)
                                 }
                             }
-                            if (responseStatus !== 200) {
-                                logger.error("All attemps failed. Exiting application.")
+                            if (!response || response.status !== 200) {
+                                logger.error("All attempts failed. Exiting application.")
+                                runStats.failed++
                                 process.exit(1)
                             }
-                        })
+                            finalStatus = response.status
+                        }
+                    }
+
+                    if (skipUpdate) {
+                        await delay(100)
+                        continue
+                    }
+
+                    const statusForLog = typeof finalStatus === "number" ? finalStatus : null
+                    if (statusForLog === 200) runStats.succeeded++
+                    else runStats.failed++
 
                     const audioMessage = stream.audioStreamId ? `Audio ID ${stream.audioStreamId}` : ""
                     const subtitleMessage = stream.subtitleStreamId >= 0 ? `Subtitle ID ${stream.subtitleStreamId}` : ""
                     const updateMessage = [audioMessage, subtitleMessage].filter(Boolean).join(" and ")
                     logger.debug(
                         `Update ${updateMessage} for user ${username} in group ${group}: ${
-                            response.status === 200 ? "SUCCESS" : "FAIL"
+                            statusForLog === 200 ? "SUCCESS" : "FAIL"
                         }`
                     )
                 } catch (error) {
@@ -556,6 +637,7 @@ const performDryRun = async () => {
 // Partial run: process items updated since last run
 const performPartialRun = async (cleanRun) => {
     await fetchAllLibraries()
+    resetRunStats()
 
     logger.info(`STARTING ${cleanRun ? "CLEAN" : "PARTIAL"} RUN`)
 
@@ -636,6 +718,7 @@ const performPartialRun = async (cleanRun) => {
     // Save the updated timestamps for future runs
     if (Object.keys(newTimestamps).length > 0) saveLastRunTimestamps({ ...lastRunTimestamps, ...newTimestamps })
 
+    logRunSummary()
     logger.info(`FINISHED ${cleanRun ? "CLEAN" : "PARTIAL"} RUN`)
 }
 


### PR DESCRIPTION
## Summary
- add a `skipInaccessibleItems` configuration option with an environment override to control skipping inaccessible updates
- update per-item update logic to bypass HTTP 403 responses when configured, track skip metrics, and preserve retries for other errors
- log per-run processing statistics and document the new behaviour in the README, sample config, and CHANGELOG

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de03dc6334832181b70255493913d0