### PR TITLE
Add enhanced diagnostics and audit logging

### DIFF
--- a/auditWriter.js
+++ b/auditWriter.js
@@ -1,0 +1,88 @@
+const fs = require("fs")
+const path = require("path")
+
+const ensureDir = (dir) => {
+    if (!dir) return
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+    }
+}
+
+class AuditWriter {
+    constructor(baseDir) {
+        this.baseDir = baseDir
+        this.jsonStream = null
+        this.csvStream = null
+        this.firstJsonEntry = true
+        this.active = Boolean(baseDir)
+        if (!this.active) return
+
+        ensureDir(baseDir)
+        const timestamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "")
+        const jsonPath = path.join(baseDir, `run-${timestamp}.json`)
+        const csvPath = path.join(baseDir, `run-${timestamp}.csv`)
+
+        this.jsonStream = fs.createWriteStream(jsonPath, { flags: "a" })
+        this.jsonStream.write("[\n")
+
+        this.csvStream = fs.createWriteStream(csvPath, { flags: "a" })
+        this.csvStream.write(
+            "timestamp,libraryName,ratingKey,partId,title,group,user,actionType,fromStreamId,fromLabel,toStreamId,toLabel,status,reason,httpStatus,durationMs\n"
+        )
+    }
+
+    append(entry) {
+        if (!this.active) return
+        const serialized = JSON.stringify(entry)
+        if (!this.firstJsonEntry) {
+            this.jsonStream.write(",\n")
+        }
+        this.jsonStream.write(serialized)
+        this.firstJsonEntry = false
+
+        const escapeCsv = (value) => {
+            if (value === undefined || value === null) return ""
+            const stringValue = String(value)
+            if (/[",\n]/.test(stringValue)) {
+                return `"${stringValue.replace(/"/g, '""')}"`
+            }
+            return stringValue
+        }
+
+        const csvValues = [
+            entry.timestamp,
+            entry.libraryName,
+            entry.ratingKey,
+            entry.partId,
+            entry.title,
+            entry.group,
+            entry.user,
+            entry.actionType,
+            entry.fromStreamId,
+            entry.fromLabel,
+            entry.toStreamId,
+            entry.toLabel,
+            entry.status,
+            entry.reason,
+            entry.httpStatus,
+            entry.durationMs,
+        ]
+            .map((value) => escapeCsv(value))
+            .join(",")
+
+        this.csvStream.write(`${csvValues}\n`)
+    }
+
+    close() {
+        if (!this.active) return
+        if (this.jsonStream) {
+            this.jsonStream.write("\n]\n")
+            this.jsonStream.end()
+        }
+        if (this.csvStream) {
+            this.csvStream.end()
+        }
+    }
+}
+
+module.exports = AuditWriter

--- a/cliOptions.js
+++ b/cliOptions.js
@@ -1,0 +1,63 @@
+const toCamelCase = (input) =>
+    input
+        .replace(/^no-/, "")
+        .split(/[-_]/)
+        .map((part, index) => (index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+        .join("")
+
+const parseValue = (raw) => {
+    if (raw === undefined) return true
+    const normalized = raw.trim().toLowerCase()
+    if (["true", "1", "yes", "on"].includes(normalized)) return true
+    if (["false", "0", "no", "off"].includes(normalized)) return false
+    return raw
+}
+
+const args = process.argv.slice(2)
+const positional = []
+const flags = {}
+
+for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (!arg.startsWith("--")) {
+        positional.push(arg)
+        continue
+    }
+
+    const trimmed = arg.slice(2)
+    if (trimmed.length === 0) continue
+
+    let key
+    let value
+
+    if (trimmed.includes("=")) {
+        const [rawKey, rawValue] = trimmed.split(/=(.*)/)
+        key = rawKey
+        value = parseValue(rawValue)
+    } else {
+        key = trimmed
+        const next = args[index + 1]
+        if (next && !next.startsWith("--")) {
+            value = parseValue(next)
+            index++
+        } else if (trimmed.startsWith("no-")) {
+            value = false
+        } else {
+            value = true
+        }
+    }
+
+    const camelKey = toCamelCase(key)
+    flags[camelKey] = value
+}
+
+const getFlag = (name) => {
+    if (Object.prototype.hasOwnProperty.call(flags, name)) return flags[name]
+    return undefined
+}
+
+module.exports = {
+    positional,
+    flags,
+    getFlag,
+}

--- a/configBuilder.js
+++ b/configBuilder.js
@@ -1,11 +1,11 @@
 const fs = require("fs")
 const yaml = require("js-yaml")
 const logger = require("./logger")
+const cliOptions = require("./cliOptions")
 const Ajv = require("ajv")
 const ajv = new Ajv()
 
-// Path to YAML file
-const yamlFilePath = process.argv[3] || "./config.yaml"
+const yamlFilePath = cliOptions.getFlag("config") || cliOptions.positional[1] || "./config.yaml"
 
 // Define the updated validation schema
 const schema = {
@@ -24,6 +24,9 @@ const schema = {
             type: "object",
             additionalProperties: { type: "string" },
         },
+        logUserSummary: { type: "boolean" },
+        logJsonUserSummary: { type: "boolean" },
+        auditDir: { type: "string" },
         groups: {
             type: "object",
             patternProperties: {

--- a/logger.js
+++ b/logger.js
@@ -2,8 +2,10 @@ const path = require("path")
 const winston = require("winston")
 const DailyRotateFile = require("winston-daily-rotate-file")
 
+const cliOptions = require("./cliOptions")
+
 const logLevel = process.env.LOG_LEVEL || "info"
-const filePath = process.argv[2] || "./logs"
+const filePath = cliOptions.positional[0] || "./logs"
 
 const logger = winston.createLogger({
     level: logLevel,

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "ajv": "^8.17.1",
     "axios": "^1.8.0",

--- a/test/auditWriter.test.js
+++ b/test/auditWriter.test.js
@@ -1,0 +1,76 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("fs")
+const path = require("path")
+const os = require("os")
+
+const AuditWriter = require("../auditWriter")
+
+const readFirstFile = (dir, extension) => {
+    const files = fs.readdirSync(dir).filter((file) => file.endsWith(extension))
+    assert.ok(files.length > 0, `expected ${extension} file in ${dir}`)
+    return path.join(dir, files[0])
+}
+
+test("audit writer produces JSON and CSV rows", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-writer-"))
+    const writer = new AuditWriter(tempDir)
+
+    writer.append({
+        timestamp: "2024-01-01T00:00:00Z",
+        libraryName: "Movies",
+        ratingKey: "1",
+        partId: "10",
+        title: "Example",
+        group: "groupA",
+        user: "alice",
+        actionType: "audio",
+        fromStreamId: "100",
+        fromLabel: "Old",
+        toStreamId: "200",
+        toLabel: "New",
+        status: "success",
+        reason: "",
+        httpStatus: 200,
+        durationMs: 123,
+    })
+
+    writer.append({
+        timestamp: "2024-01-01T00:00:01Z",
+        libraryName: "Movies",
+        ratingKey: "2",
+        partId: "20",
+        title: "Second",
+        group: "groupB",
+        user: "bob",
+        actionType: "subtitles",
+        fromStreamId: "",
+        fromLabel: "",
+        toStreamId: "300",
+        toLabel: "Enabled",
+        status: "skipped",
+        reason: "no_token",
+        httpStatus: 403,
+        durationMs: 456,
+    })
+
+    writer.close()
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    const jsonPath = readFirstFile(tempDir, ".json")
+    const jsonContent = fs.readFileSync(jsonPath, "utf-8")
+    const data = JSON.parse(jsonContent)
+    assert.equal(data.length, 2)
+    assert.equal(data[0].user, "alice")
+    assert.equal(data[1].status, "skipped")
+
+    const csvPath = readFirstFile(tempDir, ".csv")
+    const csvLines = fs.readFileSync(csvPath, "utf-8").trim().split(/\r?\n/)
+    assert.equal(csvLines.length, 3)
+    assert.equal(csvLines[0], "timestamp,libraryName,ratingKey,partId,title,group,user,actionType,fromStreamId,fromLabel,toStreamId,toLabel,status,reason,httpStatus,durationMs")
+    assert.ok(csvLines[1].includes("alice"))
+    assert.ok(csvLines[2].includes("no_token"))
+
+    fs.rmSync(tempDir, { recursive: true, force: true })
+})

--- a/test/cliOptions.test.js
+++ b/test/cliOptions.test.js
@@ -1,0 +1,43 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+
+const loadCliOptions = () => {
+    delete require.cache[require.resolve("../cliOptions")]
+    return require("../cliOptions")
+}
+
+test("cliOptions parses booleans, strings, and positional arguments", () => {
+    const originalArgv = process.argv
+    process.argv = [
+        originalArgv[0],
+        originalArgv[1],
+        "--log-user-summary",
+        "--audit-dir",
+        "/tmp/audit",
+        "./logs",
+        "./config.yaml",
+        "timestamps.json",
+    ]
+
+    const options = loadCliOptions()
+
+    assert.equal(options.getFlag("logUserSummary"), true)
+    assert.equal(options.getFlag("auditDir"), "/tmp/audit")
+    assert.deepEqual(options.positional, ["./logs", "./config.yaml", "timestamps.json"])
+
+    process.argv = originalArgv
+    loadCliOptions()
+})
+
+test("cliOptions parses negated booleans", () => {
+    const originalArgv = process.argv
+    process.argv = [originalArgv[0], originalArgv[1], "--no-log-user-summary", "--log-json-user-summary=false"]
+
+    const options = loadCliOptions()
+
+    assert.equal(options.getFlag("logUserSummary"), false)
+    assert.equal(options.getFlag("logJsonUserSummary"), false)
+
+    process.argv = originalArgv
+    loadCliOptions()
+})


### PR DESCRIPTION
## Summary
- add a shared CLI/ENV option parser, extend config schema, and wire new diagnostics flags into runtime
- introduce per-run audit writer, per-user summary logging, and hardened session handling with startup digests and owner safety messages
- document diagnostics options and add node-based tests covering CLI parsing and audit output formatting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de360104048321a8241567fa28001e