### PR TITLE
Expand diagnostics coverage and documentation

### DIFF
--- a/startupDigest.js
+++ b/startupDigest.js
@@ -1,0 +1,72 @@
+const getGroupMembers = (groupName, groupsConfig = {}, users = new Map(), ownerName) => {
+    const groupMembers = groupsConfig[groupName] || []
+    const members = new Set()
+    const ownerExplicitlyIncluded = ownerName && groupMembers.includes(ownerName)
+
+    if (groupMembers.includes("$ALL")) {
+        users.forEach((_, username) => {
+            if (username === ownerName && !ownerExplicitlyIncluded) return
+            members.add(username)
+        })
+    }
+
+    groupMembers.forEach((member) => {
+        if (member === "$ALL") return
+        members.add(member)
+    })
+
+    if (!ownerExplicitlyIncluded && groupMembers.includes("$ALL")) {
+        members.delete(ownerName)
+    }
+
+    return [...members]
+}
+
+const logGroupDigest = (config, users, logger, missingTokenWarnings = new Set()) => {
+    const filters = config.filters || {}
+    const groupsConfig = config.groups || {}
+
+    Object.entries(filters).forEach(([libraryName, libraryGroups]) => {
+        Object.keys(libraryGroups || {}).forEach((groupName) => {
+            const members = getGroupMembers(groupName, groupsConfig, users, config.plex_owner_name)
+            const resolvedMembers = members.filter((member) => users.has(member))
+            const unresolvedMembers = members.filter((member) => !users.has(member))
+
+            const memberList = resolvedMembers.length > 0 ? resolvedMembers.join(", ") : "none"
+            const parts = [
+                `Group digest (library='${libraryName}', group='${groupName}')`,
+                `members=[${memberList}]`,
+                `tokens resolved ${resolvedMembers.length}/${members.length}`,
+            ]
+
+            if (unresolvedMembers.length > 0) {
+                parts.push(`missing tokens=[${unresolvedMembers.join(", ")}]`)
+            }
+
+            logger.info(parts.join("; "))
+
+            unresolvedMembers.forEach((member) => {
+                const key = `${groupName}|${member}`
+                if (missingTokenWarnings.has(key)) return
+                missingTokenWarnings.add(key)
+                logger.warn(`no token for user '${member}' in group '${groupName}' -> will skip`)
+            })
+        })
+    })
+}
+
+const logOwnerSafety = (config, logger) => {
+    if (!config.plex_owner_name) return
+    const owner = config.plex_owner_name
+    const groupsContainingOwner = Object.entries(config.groups || {})
+        .filter(([, members]) => members.includes(owner))
+        .map(([name]) => name)
+
+    if (groupsContainingOwner.length === 0) {
+        logger.info(`Owner '${owner}' is not included in any group; no owner updates will be performed.`)
+    } else {
+        logger.warn(`Owner '${owner}' appears in groups: [${groupsContainingOwner.join(", ")}]. Proceeding per config.`)
+    }
+}
+
+module.exports = { getGroupMembers, logGroupDigest, logOwnerSafety }

--- a/streamUpdater.js
+++ b/streamUpdater.js
@@ -1,0 +1,293 @@
+const { createUserClient } = require("./utils/userClient")
+
+const describeActionType = (stream) => {
+    const audio = Boolean(stream.audioStreamId)
+    const subtitles = stream.subtitleStreamId !== undefined && stream.subtitleStreamId >= 0
+    if (audio && subtitles) return "audio+subtitles"
+    if (audio) return "audio"
+    if (subtitles) return "subtitles"
+    return "none"
+}
+
+const buildStreamTransition = (stream) => {
+    const fromIds = []
+    const fromLabels = []
+    const toIds = []
+    const toLabels = []
+
+    if (stream.audioStreamId) {
+        fromIds.push(stream.fromAudioStreamId ?? "")
+        fromLabels.push(stream.fromAudioStreamLabel || "")
+        toIds.push(stream.audioStreamId)
+        toLabels.push(stream.audioStreamLabel || "")
+    }
+
+    if (stream.subtitleStreamId !== undefined && stream.subtitleStreamId >= 0) {
+        fromIds.push(stream.fromSubtitleStreamId ?? "")
+        fromLabels.push(stream.fromSubtitleStreamLabel || "")
+        toIds.push(stream.subtitleStreamId)
+        toLabels.push(stream.subtitleStreamLabel || "")
+    }
+
+    return {
+        fromStreamId: fromIds.join("|") || null,
+        fromLabel: fromLabels.join(" | ") || null,
+        toStreamId: toIds.join("|") || null,
+        toLabel: toLabels.join(" | ") || null,
+    }
+}
+
+const createStreamUpdater = ({
+    config,
+    logger,
+    userTokens,
+    auditWriter,
+    emitUserSummary,
+    delay,
+    maskToken,
+    recordSkipForUser,
+    runStats,
+    onFatalError,
+    clientFactory,
+}) => {
+    const buildAuditEntry = ({
+        timestamp,
+        libraryName,
+        stream,
+        group,
+        username,
+        status,
+        reason,
+        httpStatus,
+        durationMs,
+    }) => {
+        const transition = buildStreamTransition(stream)
+        auditWriter.append({
+            timestamp,
+            libraryName,
+            ratingKey: stream.ratingKey,
+            partId: stream.partId,
+            title: stream.title,
+            group,
+            user: username,
+            actionType: describeActionType(stream),
+            ...transition,
+            status,
+            reason: reason ?? null,
+            httpStatus: httpStatus ?? null,
+            durationMs: typeof durationMs === "number" ? durationMs : 0,
+        })
+    }
+
+    const getClient = (username, token) => {
+        if (clientFactory) return clientFactory(username, token)
+        return createUserClient(
+            {
+                baseURL: config.plex_server_url,
+                clientIdentifier: config.plex_client_identifier,
+            },
+            { username, token }
+        )
+    }
+
+    const updateDefaultStreamsPerItem = async (libraryName, streamsToUpdate, usersWithAccess, options = {}) => {
+        const { dryRun = false, maxAttempts = 10 } = options
+
+        for (const group of Object.keys(streamsToUpdate)) {
+            for (const stream of streamsToUpdate[group]) {
+                const usernames = usersWithAccess.get(group)
+                if (!usernames || usernames.length === 0) {
+                    logger.warn(`No users found in group '${group}'. Skipping update.`)
+                    continue
+                }
+
+                const summary = {
+                    libraryName,
+                    group,
+                    partId: stream.partId,
+                    ratingKey: stream.ratingKey,
+                    title: stream.title,
+                    users: [],
+                }
+
+                const queryParams = new URLSearchParams()
+                if (stream.audioStreamId) queryParams.append("audioStreamID", stream.audioStreamId)
+                if (stream.subtitleStreamId >= 0) queryParams.append("subtitleStreamID", stream.subtitleStreamId)
+
+                for (const username of usernames) {
+                    const token = userTokens.get(username)
+                    const userSummary = { name: username }
+                    if (stream.audioStreamId) {
+                        userSummary.audio = { id: stream.audioStreamId, label: stream.audioStreamLabel || "" }
+                    }
+                    if (stream.subtitleStreamId >= 0) {
+                        userSummary.subtitles = {
+                            id: stream.subtitleStreamId,
+                            label: stream.subtitleStreamLabel || "",
+                        }
+                    }
+
+                    if (!token) {
+                        logger.warn(`No access token found for user ${username}. Skipping update.`)
+                        userSummary.status = "skipped"
+                        userSummary.reason = "no_token"
+                        summary.users.push(userSummary)
+                        buildAuditEntry({
+                            timestamp: new Date().toISOString(),
+                            libraryName,
+                            stream,
+                            group,
+                            username,
+                            status: "skipped",
+                            reason: "no_token",
+                            httpStatus: null,
+                            durationMs: 0,
+                        })
+                        continue
+                    }
+
+                    if (dryRun) {
+                        userSummary.status = "dry_run"
+                        summary.users.push(userSummary)
+                        buildAuditEntry({
+                            timestamp: new Date().toISOString(),
+                            libraryName,
+                            stream,
+                            group,
+                            username,
+                            status: "dry_run",
+                            reason: null,
+                            httpStatus: null,
+                            durationMs: 0,
+                        })
+                        continue
+                    }
+
+                    const userClient = getClient(username, token)
+
+                    runStats.processed++
+                    const startTime = Date.now()
+                    let skipUpdate = false
+                    let httpStatus = null
+                    let reason = null
+
+                    let response
+                    let attempt = 0
+                    let fatalError = false
+                    while (attempt < maxAttempts && !response && !skipUpdate) {
+                        try {
+                            response = await userClient.post(`/library/parts/${stream.partId}?${queryParams.toString()}`)
+                            httpStatus = response.status
+                            if (response.status === 200) {
+                                runStats.succeeded++
+                                userSummary.status = "success"
+                                userSummary.httpStatus = response.status
+                            } else {
+                                runStats.failed++
+                                userSummary.status = "error"
+                                reason = `HTTP ${response.status}`
+                                userSummary.reason = reason
+                                userSummary.httpStatus = response.status
+                            }
+                        } catch (error) {
+                            httpStatus = error.response?.status ?? null
+                            if (httpStatus === 403 && config.skipInaccessibleItems) {
+                                skipUpdate = true
+                                recordSkipForUser(username)
+                                reason = "HTTP 403"
+                                userSummary.status = "skipped"
+                                userSummary.reason = "HTTP 403"
+                                userSummary.httpStatus = httpStatus
+                                const itemLabel = stream.title
+                                    ? `'${stream.title}' (Part ID ${stream.partId})`
+                                    : `Part ID ${stream.partId}`
+                                logger.warn(
+                                    `Skipping item ${itemLabel} for user ${username} in group ${group}: inaccessible (HTTP 403, token ${maskToken(
+                                        token
+                                    )}).`
+                                )
+                            } else {
+                                reason = error.message || error.response?.statusText || "Unknown error"
+                                userSummary.status = "error"
+                                userSummary.reason = reason
+                                userSummary.httpStatus = httpStatus
+                                const messageSuffix =
+                                    httpStatus === 403
+                                        ? ". This could be because of age ratings, ensure they can access ALL items in the library"
+                                        : ""
+                                if (attempt < maxAttempts - 1) {
+                                    logger.error(
+                                        `Attempt ${attempt + 1}/${maxAttempts} failed for user ${username} in group ${group}${messageSuffix}: ${reason}. Retrying in 30 sec...`
+                                    )
+                                    attempt++
+                                    await delay(30000)
+                                } else {
+                                    fatalError = true
+                                    runStats.failed++
+                                    logger.error(
+                                        `All attempts failed for user ${username} in group ${group}. Reason: ${reason}. Exiting application.`
+                                    )
+                                    break
+                                }
+                            }
+                        }
+                    }
+
+                    const duration = Date.now() - startTime
+                    buildAuditEntry({
+                        timestamp: new Date(startTime).toISOString(),
+                        libraryName,
+                        stream,
+                        group,
+                        username,
+                        status: skipUpdate ? "skipped" : userSummary.status || "error",
+                        reason,
+                        httpStatus,
+                        durationMs: duration,
+                    })
+
+                    if (!skipUpdate && !userSummary.status) {
+                        userSummary.status = httpStatus === 200 ? "success" : "error"
+                        if (httpStatus !== 200) userSummary.reason = reason
+                    }
+
+                    if (skipUpdate) {
+                        await delay(100)
+                        summary.users.push(userSummary)
+                        continue
+                    }
+
+                    const statusForLog = httpStatus
+                    const audioMessage = stream.audioStreamId ? `Audio ID ${stream.audioStreamId}` : ""
+                    const subtitleMessage = stream.subtitleStreamId >= 0 ? `Subtitle ID ${stream.subtitleStreamId}` : ""
+                    const updateMessage = [audioMessage, subtitleMessage].filter(Boolean).join(" and ")
+                    logger.debug(
+                        `Update ${updateMessage} for user ${username} in group ${group}: ${
+                            statusForLog === 200 ? "SUCCESS" : "FAIL"
+                        }`
+                    )
+
+                    summary.users.push(userSummary)
+                    if (fatalError) {
+                        emitUserSummary(summary)
+                        if (onFatalError) onFatalError()
+                        return false
+                    }
+                    await delay(100)
+                }
+
+                logger.info(`Part ID ${stream.partId}: update complete for group ${group}`)
+                emitUserSummary(summary)
+            }
+        }
+        return true
+    }
+
+    return {
+        updateDefaultStreamsPerItem,
+        describeActionType,
+        buildStreamTransition,
+    }
+}
+
+module.exports = { createStreamUpdater, describeActionType, buildStreamTransition }

--- a/summaryEmitter.js
+++ b/summaryEmitter.js
@@ -1,0 +1,51 @@
+const createUserSummaryEmitter = (config, logger) => {
+    return (summary) => {
+        if (!config.logUserSummary && !config.logJsonUserSummary) return
+
+        if (config.logJsonUserSummary) {
+            const jsonPayload = {
+                event: "user_updates",
+                library: summary.libraryName,
+                group: summary.group,
+                partId: summary.partId,
+                ratingKey: summary.ratingKey,
+                title: summary.title,
+                users: summary.users.map((user) => {
+                    const payload = { name: user.name, status: user.status }
+                    if (user.audio) payload.audio = user.audio
+                    if (user.subtitles) payload.subtitles = user.subtitles
+                    if (user.reason) payload.reason = user.reason
+                    if (user.httpStatus) payload.httpStatus = user.httpStatus
+                    return payload
+                }),
+            }
+            logger.info(JSON.stringify(jsonPayload))
+        }
+
+        if (config.logUserSummary) {
+            const header = `User summary (library='${summary.libraryName}', group='${summary.group}', part=${summary.partId}, title='${summary.title}'):`
+            const userSegments = summary.users.map((user) => {
+                const detailSegments = []
+                if (user.audio) detailSegments.push(`audio='${user.audio.label}' (id=${user.audio.id})`)
+                if (user.subtitles) {
+                    detailSegments.push(
+                        user.subtitles.id === 0
+                            ? "subtitles=disabled"
+                            : `subtitles='${user.subtitles.label}' (id=${user.subtitles.id})`
+                    )
+                }
+
+                const statusSuffix = user.reason && user.status !== "success"
+                    ? `[${user.status}: ${user.reason}]`
+                    : `[${user.status}]`
+
+                const detailPrefix = detailSegments.length > 0 ? `${detailSegments.join(", ")} ` : ""
+                return `${user.name}: ${detailPrefix}${statusSuffix}`.trim()
+            })
+
+            logger.info(`${header} ${userSegments.join(", ")}`)
+        }
+    }
+}
+
+module.exports = { createUserSummaryEmitter }

--- a/test/startupDigest.test.js
+++ b/test/startupDigest.test.js
@@ -1,0 +1,86 @@
+const test = require("node:test")
+const assert = require("node:assert")
+
+const { logGroupDigest, getGroupMembers, logOwnerSafety } = require("../startupDigest")
+
+const createFakeLogger = () => {
+    const info = []
+    const warn = []
+    return {
+        info: (message) => info.push(message),
+        warn: (message) => warn.push(message),
+        infoMessages: info,
+        warnMessages: warn,
+    }
+}
+
+test("logGroupDigest reports members and resolved tokens", () => {
+    const config = {
+        plex_owner_name: "owner",
+        groups: { crew: ["alice", "bob"] },
+        filters: { Movies: { crew: {} } },
+    }
+    const users = new Map([
+        ["alice", "token-a"],
+        ["bob", "token-b"],
+    ])
+    const logger = createFakeLogger()
+
+    logGroupDigest(config, users, logger)
+
+    assert.equal(logger.infoMessages.length, 1)
+    assert.equal(
+        logger.infoMessages[0],
+        "Group digest (library='Movies', group='crew'); members=[alice, bob]; tokens resolved 2/2"
+    )
+    assert.equal(logger.warnMessages.length, 0)
+})
+
+test("logGroupDigest warns when tokens are missing", () => {
+    const config = {
+        plex_owner_name: "owner",
+        groups: { crew: ["alice", "bob"] },
+        filters: { Movies: { crew: {} } },
+    }
+    const users = new Map([["alice", "token-a"]])
+    const logger = createFakeLogger()
+
+    logGroupDigest(config, users, logger)
+
+    assert.equal(logger.infoMessages.length, 1)
+    assert.equal(
+        logger.infoMessages[0],
+        "Group digest (library='Movies', group='crew'); members=[alice]; tokens resolved 1/2; missing tokens=[bob]"
+    )
+    assert.deepEqual(logger.warnMessages, ["no token for user 'bob' in group 'crew' -> will skip"])
+})
+
+test("getGroupMembers excludes owner unless explicitly included", () => {
+    const groupsConfig = { everyone: ["$ALL"] }
+    const users = new Map([
+        ["owner", "token-owner"],
+        ["alice", "token-a"],
+    ])
+
+    const members = getGroupMembers("everyone", groupsConfig, users, "owner")
+
+    assert.deepEqual(members.sort(), ["alice"])
+})
+
+test("logOwnerSafety warns when owner is configured", () => {
+    const config = { plex_owner_name: "owner", groups: { crew: ["owner"] } }
+    const logger = createFakeLogger()
+
+    logOwnerSafety(config, logger)
+
+    assert.deepEqual(logger.warnMessages, ["Owner 'owner' appears in groups: [crew]. Proceeding per config."])
+})
+
+test("logOwnerSafety informs when owner absent", () => {
+    const config = { plex_owner_name: "owner", groups: { crew: ["alice"] } }
+    const logger = createFakeLogger()
+
+    logOwnerSafety(config, logger)
+
+    assert.deepEqual(logger.infoMessages, ["Owner 'owner' is not included in any group; no owner updates will be performed."])
+})

--- a/test/streamUpdater.test.js
+++ b/test/streamUpdater.test.js
@@ -1,0 +1,356 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+
+const { createStreamUpdater } = require("../streamUpdater")
+
+const createLogger = () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+})
+
+const createCapturingLogger = () => {
+    const info = []
+    const warn = []
+    const error = []
+    const debug = []
+    return {
+        info: (message) => info.push(message),
+        warn: (message) => warn.push(message),
+        error: (message) => error.push(message),
+        debug: (message) => debug.push(message),
+        infoMessages: info,
+        warnMessages: warn,
+        errorMessages: error,
+        debugMessages: debug,
+    }
+}
+
+const createRunStats = () => ({ processed: 0, succeeded: 0, failed: 0, skipped: 0, skippedByUser: {} })
+
+const createRecordSkip = (runStats) => (username) => {
+    runStats.skipped++
+    runStats.skippedByUser[username] = (runStats.skippedByUser[username] || 0) + 1
+}
+
+test("success path records audit entry and uses per-user token", async () => {
+    const auditEntries = []
+    const summaries = []
+    const tokensUsed = []
+    const config = { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: false }
+    const runStats = createRunStats()
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config,
+        logger: createLogger(),
+        userTokens: new Map([["alice", "alice-token"], ["owner", "owner-token"]]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: (summary) => summaries.push(summary),
+        delay: async () => {},
+        maskToken: (token) => token,
+        recordSkipForUser: createRecordSkip(runStats),
+        runStats,
+        onFatalError: () => {
+            throw new Error("fatal should not be called")
+        },
+        clientFactory: (username, token) => {
+            tokensUsed.push(token)
+            return { post: async () => ({ status: 200 }) }
+        },
+    })
+
+    const usersWithAccess = new Map([["groupA", ["alice"]]])
+    const stream = {
+        partId: 10,
+        ratingKey: 100,
+        title: "Example",
+        audioStreamId: 200,
+        audioStreamLabel: "Stereo",
+    }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess)
+
+    assert.deepEqual(tokensUsed, ["alice-token"])
+    assert.equal(runStats.processed, 1)
+    assert.equal(runStats.succeeded, 1)
+    assert.equal(auditEntries.length, 1)
+    assert.equal(auditEntries[0].status, "success")
+    assert.equal(auditEntries[0].httpStatus, 200)
+    assert.equal(auditEntries[0].reason, null)
+    assert.ok(auditEntries[0].durationMs >= 0)
+    assert.equal(summaries.length, 1)
+    assert.equal(summaries[0].users[0].status, "success")
+})
+
+test("403 inaccessible is skipped with audit row and human summary", async () => {
+    const auditEntries = []
+    const summaries = []
+    const runStats = createRunStats()
+    const config = { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: true }
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config,
+        logger: createLogger(),
+        userTokens: new Map([["bob", "bob-token"]]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: (summary) => summaries.push(summary),
+        delay: async () => {},
+        maskToken: (token) => `masked-${token}`,
+        recordSkipForUser: createRecordSkip(runStats),
+        runStats,
+        onFatalError: () => {
+            throw new Error("fatal should not be called")
+        },
+        clientFactory: () => ({
+            post: async () => {
+                const error = new Error("Forbidden")
+                error.response = { status: 403 }
+                throw error
+            },
+        }),
+    })
+
+    const usersWithAccess = new Map([["groupA", ["bob"]]])
+    const stream = { partId: 11, ratingKey: 101, title: "Item", audioStreamId: 1 }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess, { maxAttempts: 1 })
+
+    assert.equal(runStats.skipped, 1)
+    assert.equal(auditEntries.length, 1)
+    assert.equal(auditEntries[0].status, "skipped")
+    assert.equal(auditEntries[0].reason, "HTTP 403")
+    assert.equal(auditEntries[0].httpStatus, 403)
+    assert.equal(summaries.length, 1)
+    assert.equal(summaries[0].users.length, 1)
+    const userSummary = summaries[0].users[0]
+    assert.equal(userSummary.name, "bob")
+    assert.equal(userSummary.status, "skipped")
+    assert.equal(userSummary.reason, "HTTP 403")
+    assert.equal(userSummary.httpStatus, 403)
+})
+
+test("500 error writes audit row and triggers fatal handler", async () => {
+    const auditEntries = []
+    const runStats = createRunStats()
+    let fatalCalled = false
+    const config = { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: false }
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config,
+        logger: createLogger(),
+        userTokens: new Map([["carol", "carol-token"]]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: () => {},
+        delay: async () => {},
+        maskToken: (token) => token,
+        recordSkipForUser: createRecordSkip(runStats),
+        runStats,
+        onFatalError: () => {
+            fatalCalled = true
+        },
+        clientFactory: () => ({
+            post: async () => {
+                const error = new Error("Server error")
+                error.response = { status: 500 }
+                throw error
+            },
+        }),
+    })
+
+    const usersWithAccess = new Map([["groupA", ["carol"]]])
+    const stream = { partId: 12, ratingKey: 102, title: "Item" }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess, { maxAttempts: 1 })
+
+    assert.equal(fatalCalled, true)
+    assert.equal(auditEntries.length, 1)
+    assert.equal(auditEntries[0].status, "error")
+    assert.equal(auditEntries[0].httpStatus, 500)
+    assert.equal(auditEntries[0].reason, "Server error")
+})
+
+test("dry run records audit entries without invoking client", async () => {
+    const auditEntries = []
+    const summaries = []
+    const tokensUsed = []
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config: { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: false },
+        logger: createLogger(),
+        userTokens: new Map([["dave", "dave-token"]]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: (summary) => summaries.push(summary),
+        delay: async () => {},
+        maskToken: (token) => token,
+        recordSkipForUser: () => {},
+        runStats: createRunStats(),
+        onFatalError: () => {
+            throw new Error("fatal should not be called")
+        },
+        clientFactory: (username, token) => {
+            tokensUsed.push(token)
+            return { post: async () => ({ status: 200 }) }
+        },
+    })
+
+    const usersWithAccess = new Map([["groupA", ["dave"]]])
+    const stream = { partId: 13, ratingKey: 103, title: "Dry", audioStreamId: 1 }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess, { dryRun: true })
+
+    assert.equal(tokensUsed.length, 0)
+    assert.equal(auditEntries.length, 1)
+    assert.equal(auditEntries[0].status, "dry_run")
+    assert.equal(auditEntries[0].httpStatus, null)
+    assert.equal(auditEntries[0].durationMs, 0)
+    assert.equal(summaries.length, 1)
+    assert.equal(summaries[0].users[0].status, "dry_run")
+})
+
+test("missing token is recorded as skipped", async () => {
+    const auditEntries = []
+    const summaries = []
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config: { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: false },
+        logger: createLogger(),
+        userTokens: new Map(),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: (summary) => summaries.push(summary),
+        delay: async () => {},
+        maskToken: (token) => token,
+        recordSkipForUser: () => {},
+        runStats: createRunStats(),
+        onFatalError: () => {
+            throw new Error("fatal should not be called")
+        },
+    })
+
+    const usersWithAccess = new Map([["groupA", ["erin"]]])
+    const stream = { partId: 14, ratingKey: 104, title: "Skip", audioStreamId: 1 }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess)
+
+    assert.equal(auditEntries.length, 1)
+    assert.equal(auditEntries[0].status, "skipped")
+    assert.equal(auditEntries[0].reason, "no_token")
+    assert.equal(auditEntries[0].httpStatus, null)
+    assert.equal(summaries.length, 1)
+    const summary = summaries[0].users[0]
+    assert.equal(summary.name, "erin")
+    assert.equal(summary.status, "skipped")
+    assert.equal(summary.reason, "no_token")
+})
+
+test("owner token is ignored when owner not in group", async () => {
+    const auditEntries = []
+    const tokensUsed = []
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config: { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: false },
+        logger: createLogger(),
+        userTokens: new Map([
+            ["alice", "alice-token"],
+            ["owner", "owner-token"],
+        ]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: () => {},
+        delay: async () => {},
+        maskToken: (token) => token,
+        recordSkipForUser: () => {},
+        runStats: createRunStats(),
+        onFatalError: () => {
+            throw new Error("fatal should not be called")
+        },
+        clientFactory: (username, token) => {
+            tokensUsed.push({ username, token })
+            return { post: async () => ({ status: 200 }) }
+        },
+    })
+
+    const usersWithAccess = new Map([["groupA", ["alice"]]])
+    const stream = { partId: 15, ratingKey: 105, title: "Ownerless" }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess)
+
+    assert.deepEqual(tokensUsed, [{ username: "alice", token: "alice-token" }])
+    assert.equal(auditEntries.length, 1)
+    assert.equal(auditEntries[0].user, "alice")
+})
+
+test("403 warnings mask user tokens", async () => {
+    const auditEntries = []
+    const logger = createCapturingLogger()
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config: { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: true },
+        logger,
+        userTokens: new Map([["bob", "bob-secret-token"]]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: () => {},
+        delay: async () => {},
+        maskToken: () => "MASKED",
+        recordSkipForUser: () => {},
+        runStats: createRunStats(),
+        onFatalError: () => {},
+        clientFactory: () => ({
+            post: async () => {
+                const error = new Error("Forbidden")
+                error.response = { status: 403 }
+                throw error
+            },
+        }),
+    })
+
+    const usersWithAccess = new Map([["groupA", ["bob"]]])
+    const stream = { partId: 16, ratingKey: 106, title: "Mask" }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess, { maxAttempts: 1 })
+
+    assert.ok(logger.warnMessages.some((message) => message.includes("MASKED")))
+    assert.ok(!logger.warnMessages.some((message) => message.includes("bob-secret-token")))
+})
+
+test("each user update uses the correct token", async () => {
+    const auditEntries = []
+    const tokensUsed = []
+    const runStats = createRunStats()
+
+    const { updateDefaultStreamsPerItem } = createStreamUpdater({
+        config: { plex_server_url: "http://plex", plex_client_identifier: "client", skipInaccessibleItems: false },
+        logger: createLogger(),
+        userTokens: new Map([
+            ["alice", "alice-token"],
+            ["bob", "bob-token"],
+        ]),
+        auditWriter: { append: (entry) => auditEntries.push(entry) },
+        emitUserSummary: () => {},
+        delay: async () => {},
+        maskToken: (token) => token,
+        recordSkipForUser: () => {},
+        runStats,
+        onFatalError: () => {},
+        clientFactory: (username, token) => {
+            tokensUsed.push({ username, token })
+            return { post: async () => ({ status: 200 }) }
+        },
+    })
+
+    const usersWithAccess = new Map([["groupA", ["alice", "bob"]]])
+    const stream = { partId: 17, ratingKey: 107, title: "Multi" }
+
+    await updateDefaultStreamsPerItem("Movies", { groupA: [stream] }, usersWithAccess)
+
+    assert.deepEqual(tokensUsed, [
+        { username: "alice", token: "alice-token" },
+        { username: "bob", token: "bob-token" },
+    ])
+    assert.equal(runStats.processed, 2)
+    assert.equal(runStats.succeeded, 2)
+    assert.equal(auditEntries.length, 2)
+    assert.deepEqual(
+        auditEntries.map((entry) => entry.user).sort(),
+        ["alice", "bob"]
+    )
+})

--- a/test/tokenMask.test.js
+++ b/test/tokenMask.test.js
@@ -1,0 +1,17 @@
+const test = require("node:test")
+const assert = require("node:assert")
+
+const { maskToken } = require("../utils/token")
+
+test("maskToken masks everything but last six characters", () => {
+    assert.equal(maskToken("1234567890abcdef"), "***…abcdef")
+})
+
+test("maskToken handles short tokens", () => {
+    assert.equal(maskToken("123"), "***")
+})
+
+test("maskToken handles empty values", () => {
+    assert.equal(maskToken(""), "(none)")
+    assert.equal(maskToken(null), "(none)")
+})

--- a/test/userClient.test.js
+++ b/test/userClient.test.js
@@ -1,0 +1,47 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+
+const { buildUserHeaders, createUserClient } = require("../utils/userClient")
+
+test("buildUserHeaders enforces per-user token isolation", () => {
+    const headers = buildUserHeaders({
+        token: "user-token-123456",
+        username: "alice",
+        clientIdentifier: "client-1",
+        deviceNamePrefix: "Defaulter",
+    })
+
+    assert.equal(headers["X-Plex-Token"], "user-token-123456")
+    assert.equal(headers["X-Plex-Client-Identifier"], "client-1")
+    assert.equal(headers["X-Plex-Device-Name"], "Defaulter/alice")
+    assert.equal(headers["X-Plex-Username"], "alice")
+})
+
+test("createUserClient passes headers to axios factory", () => {
+    const captured = []
+    const fakeAxios = {
+        create: (options) => {
+            captured.push(options)
+            return { post: async () => ({ status: 200 }) }
+        },
+    }
+
+    const client = createUserClient(
+        {
+            baseURL: "http://example.com",
+            clientIdentifier: "client-abc",
+            deviceNamePrefix: "Defaulter",
+            axiosLib: fakeAxios,
+        },
+        { username: "bob", token: "bob-token-654321" }
+    )
+
+    assert.equal(typeof client.post, "function")
+    assert.equal(captured.length, 1)
+    const options = captured[0]
+    assert.equal(options.baseURL, "http://example.com")
+    assert.equal(options.headers["X-Plex-Token"], "bob-token-654321")
+    assert.equal(options.headers["X-Plex-Client-Identifier"], "client-abc")
+    assert.equal(options.headers["X-Plex-Device-Name"], "Defaulter/bob")
+    assert.equal(options.headers["X-Plex-Username"], "bob")
+})

--- a/test/userSummary.test.js
+++ b/test/userSummary.test.js
@@ -1,0 +1,91 @@
+const test = require("node:test")
+const assert = require("node:assert")
+
+const { createUserSummaryEmitter } = require("../summaryEmitter")
+
+test("JSON summaries emit valid JSON with expected shape", () => {
+    const infoMessages = []
+    const emitter = createUserSummaryEmitter(
+        { logJsonUserSummary: true, logUserSummary: false },
+        { info: (message) => infoMessages.push(message) }
+    )
+
+    emitter({
+        libraryName: "Movies",
+        group: "crew",
+        partId: 123,
+        ratingKey: 456,
+        title: "Example",
+        users: [
+            { name: "alice", status: "success", audio: { id: 10, label: "AC3" } },
+            { name: "bob", status: "skipped", reason: "HTTP 403" },
+        ],
+    })
+
+    assert.equal(infoMessages.length, 1)
+    const parsed = JSON.parse(infoMessages[0])
+    assert.equal(parsed.event, "user_updates")
+    assert.equal(parsed.library, "Movies")
+    assert.equal(parsed.group, "crew")
+    assert.equal(parsed.partId, 123)
+    assert.equal(parsed.ratingKey, 456)
+    assert.equal(parsed.title, "Example")
+    assert.deepEqual(parsed.users, [
+        { name: "alice", status: "success", audio: { id: 10, label: "AC3" } },
+        { name: "bob", status: "skipped", reason: "HTTP 403" },
+    ])
+})
+
+test("Human summaries emit single line with statuses", () => {
+    const infoMessages = []
+    const emitter = createUserSummaryEmitter(
+        { logJsonUserSummary: false, logUserSummary: true },
+        { info: (message) => infoMessages.push(message) }
+    )
+
+    emitter({
+        libraryName: "Movies",
+        group: "crew",
+        partId: 123,
+        ratingKey: 456,
+        title: "Example",
+        users: [
+            { name: "alice", status: "success" },
+            { name: "bob", status: "skipped", reason: "HTTP 403" },
+            { name: "carol", status: "error", reason: "timeout" },
+        ],
+    })
+
+    assert.equal(infoMessages.length, 1)
+    assert.equal(
+        infoMessages[0],
+        "User summary (library='Movies', group='crew', part=123, title='Example'): alice: [success], bob: [skipped: HTTP 403], carol: [error: timeout]"
+    )
+})
+
+test("Human summaries include stream details when available", () => {
+    const infoMessages = []
+    const emitter = createUserSummaryEmitter(
+        { logJsonUserSummary: false, logUserSummary: true },
+        { info: (message) => infoMessages.push(message) }
+    )
+
+    emitter({
+        libraryName: "Movies",
+        group: "crew",
+        partId: 42,
+        ratingKey: 99,
+        title: "Detailed",
+        users: [
+            { name: "alice", status: "success", audio: { id: 10, label: "AC3" } },
+            { name: "bob", status: "success", subtitles: { id: 22, label: "English CC" } },
+            { name: "carol", status: "success", subtitles: { id: 0, label: "" } },
+        ],
+    })
+
+    assert.equal(infoMessages.length, 1)
+    assert.equal(
+        infoMessages[0],
+        "User summary (library='Movies', group='crew', part=42, title='Detailed'): alice: audio='AC3' (id=10) [success], bob: subtitles='English CC' (id=22) [success], carol: subtitles=disabled [success]"
+    )
+})

--- a/utils/token.js
+++ b/utils/token.js
@@ -1,0 +1,10 @@
+const maskToken = (token) => {
+    if (!token) return "(none)"
+
+    const normalized = token.toString().trim()
+    if (normalized.length === 0) return "(none)"
+    if (normalized.length <= 6) return "*".repeat(normalized.length)
+    return `***…${normalized.slice(-6)}`
+}
+
+module.exports = { maskToken }

--- a/utils/userClient.js
+++ b/utils/userClient.js
@@ -1,0 +1,32 @@
+const axios = require("axios")
+
+const DEFAULT_TIMEOUT = 600000
+
+const buildDeviceName = (username, prefix = "Defaulter") => {
+    const safeUsername = username || "unknown"
+    return `${prefix}/${safeUsername}`
+}
+
+const buildUserHeaders = ({ token, username, clientIdentifier, deviceNamePrefix = "Defaulter" }) => {
+    if (!token) throw new Error("token is required to build headers")
+    const headers = {
+        "X-Plex-Token": token,
+        "X-Plex-Client-Identifier": clientIdentifier,
+        "X-Plex-Device-Name": buildDeviceName(username, deviceNamePrefix),
+    }
+    if (username) headers["X-Plex-Username"] = username
+    return headers
+}
+
+const createUserClient = (
+    { baseURL, clientIdentifier, deviceNamePrefix = "Defaulter", timeout = DEFAULT_TIMEOUT, axiosLib = axios },
+    { username, token }
+) => {
+    const headers = buildUserHeaders({ token, username, clientIdentifier, deviceNamePrefix })
+    return axiosLib.create({ baseURL, timeout, headers })
+}
+
+module.exports = {
+    buildUserHeaders,
+    createUserClient,
+}


### PR DESCRIPTION
## Summary
- document diagnostics behaviour, acceptance criteria, and a manual verification plan in the README
- refine human summary formatting while ensuring JSON output remains unchanged
- extend automated coverage for skip reasons, token masking, owner isolation, and multi-user header handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68de4139fdd88321b25cda99ab12ca4e